### PR TITLE
Add tasks for release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,24 @@
+# Copyright (C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+groonga_org_repository = ENV["GROONGA_ORG_REPOSITORY"]
+if groonga_org_repository.nil?
+  raise "Specify GROONGA_ORG_REPOSITORY environment variable"
+end
+require "#{groonga_org_repository}/release_task"
+
+release_task = ReleaseTask.new("Mroonga", __dir__)
+release_task.define


### PR DESCRIPTION
This task use release_task.rb of groonga.org.

---

Usage when we generate blog:

export GROONGA_ORG_REPOSITORY=~/groonga.org
rake release:blog:generate

---

Usage when we update _config.yml and push tag

export GROONGA_ORG_REPOSITORY=~/groonga.org
rake release:version:update