### PR TITLE
blog: add a blog for 14.12

### DIFF
--- a/en/_posts/2024-12-25-mroonga-14.12.md
+++ b/en/_posts/2024-12-25-mroonga-14.12.md
@@ -1,0 +1,13 @@
+---
+layout: post.en
+title: Mroonga 14.12 has been released
+description: Mroonga 14.12 has been released!
+---
+
+## Mroonga 14.12 has been released
+
+Mroonga 14.12 has been released!
+
+For installation instructions on your environments, please see the [Installation Guide](/docs/install.html).
+
+For the information on the changes in this release, please see the [Release Note](/docs/news/14.html#release-14-12).

--- a/ja/_posts/2024-12-25-mroonga-14.12.md
+++ b/ja/_posts/2024-12-25-mroonga-14.12.md
@@ -1,0 +1,15 @@
+---
+layout: post.ja
+title: Mroonga 14.12リリース
+description: Mroonga 14.12をリリースしました！
+---
+
+## Mroonga 14.12リリース
+
+Mroonga 14.12をリリースしました！
+
+それぞれの環境毎のインストール方法は、[インストール](/ja/docs/install.html)をご確認ください。
+
+主な変更点は、[リリースノート](/ja/docs/news/14.html#release-14-12)をご確認ください。
+
+開発者がGroonga・PGroonga・Mroongaのリリース内容について自慢する動画配信、[Groonga リリース自慢会](https://www.youtube.com/playlist?list=PLLwHraQ4jf7PnA3GjI9v90DZq8ikLk0iN)もあわせてご覧ください。


### PR DESCRIPTION
We generate automatically using `rake release:blog:generate`.

See: https://github.com/mroonga/mroonga.org/pull/27